### PR TITLE
Mark the loadXML call as blocking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ class JsonXmlHttpEndpoint[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
   }
 
   private def personXmlDecoder: EntityDecoder[F, Person] =
-    org.http4s.scalaxml.xml[F].map(Person.fromXml)
+    org.http4s.scalaxml.xmlDecoder[F].map(Person.fromXml)
 
   implicit private def jsonXmlDecoder: EntityDecoder[F, Person] =
     jsonOf[F, Person].orElse(personXmlDecoder)


### PR DESCRIPTION
Fixes #27.  Source compatible for everyone who uses it implicitly and has an Async.

The need for Sync was offensive enough in JSON that we made a capability trait.  Note that we can relax it back to `Concurrent` in #25.