### PR TITLE
Parse body as an InputStream

### DIFF
--- a/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
@@ -21,6 +21,7 @@ import cats.data.EitherT
 import cats.effect.Async
 import cats.effect.Concurrent
 import cats.syntax.all._
+import fs2.io.toInputStream
 import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 
@@ -78,17 +79,21 @@ trait ElemInstances {
       val source = new InputSource()
       msg.charset.foreach(cs => source.setEncoding(cs.nioCharset.name))
 
-      collectBinary(msg).flatMap[DecodeFailure, Elem] { chunk =>
-        source.setByteStream(new ByteArrayInputStream(chunk.toArray))
-        val saxParser = saxFactory.newSAXParser()
-        EitherT(
-          F.blocking(XML.loadXML(source, saxParser))
-            .map(Either.right[DecodeFailure, Elem](_))
-            .recover { case e: SAXParseException =>
-              Left(MalformedMessageBodyFailure("Invalid XML", Some(e)))
-            }
-        )
-      }
+      EitherT(
+        msg.body
+          .through(toInputStream)
+          .evalMap { in =>
+            source.setByteStream(in)
+            val saxParser = saxFactory.newSAXParser()
+            F.blocking(XML.loadXML(source, saxParser))
+          }
+          .compile
+          .lastOrError
+          .map(Either.right[DecodeFailure, Elem](_))
+          .recover { case e: SAXParseException =>
+            Left(MalformedMessageBodyFailure("Invalid XML", Some(e)))
+          }
+      )
     }
   }
 


### PR DESCRIPTION
This should trade time for space.  Instead of materializing the entire body, we parse incrementally using `java.io.InputStream`.  It's still a blocking call, but we save a giant byte array on large payloads.